### PR TITLE
A suggestion for a little fix

### DIFF
--- a/elephantdb-cascading/src/jvm/elephantdb/cascading/ElephantDBTap.java
+++ b/elephantdb-cascading/src/jvm/elephantdb/cascading/ElephantDBTap.java
@@ -61,8 +61,13 @@ public class ElephantDBTap extends Hfs {
             this.args.sinkFields, this.spec));
     }
 
+    private transient DomainStore domainStore;
+
     public DomainStore getDomainStore() throws IOException {
-        return new DomainStore(domainDir, spec);
+        if (domainStore == null) {
+            domainStore = new DomainStore(domainDir, spec);
+        }
+        return domainStore;
     }
 
     public DomainSpec getSpec() {


### PR DESCRIPTION
Hi,

I'm using ElephantDB in combination with S3. When writing data to S3 via the ElephantDBTap I first got the impression that the process is in an endless loop. It constantly logs an info message like:

```
INFO s3native.NativeS3FileSystem: Opening '/domains/{your-domain}/domain-spec.yaml' for reading
```

After investigating this issue with the help of a Java debugger, I've seen that a new DomainStore is instantiated every time `cascading.tap.Tap/hashCode` is invoked (via getIdentifier). The instantiation of the DomainStore causes `org.apache.hadoop.fs.s3native.NativeS3FileSystem` to fetch the domain-spec.yaml file from S3 and to log the above mentioned message.

I don't know, if it is ok to cache the DomainStore in ElephantDBTap? At least it solved the issue, but maybe there is a better way to fix it?

Best regards

Max
